### PR TITLE
Add all arguments required for extension

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -22,9 +22,15 @@
     ],
     "arguments": [
         {
+            "name": "targetSPN",
+            "desc": "target SPN host (e.x. LDAP/DC01.CONTOSO.LOCAL)",
+            "type": "wstring",
+            "optional": false
+        },
+        {
             "name": "target",
-            "desc": "target host",
-            "type": "string",
+            "desc": "target host (e.x. DC01.CONTOSO.LOCAL)",
+            "type": "wstring",
             "optional": false
         }
     ]


### PR DESCRIPTION
The CNA actually passes two variables into the [BOF](https://github.com/sliverarmory/LdapSignCheck/blob/main/BofLdapSignCheck/BofLdapSignCheck.cna#L22). Since Sliver doesn't use the CNA, it's impossible to call the BOF correctly with the current extension.json